### PR TITLE
Feat/app routing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+# own ones
+.vscode/*
+
 # Miscellaneous
 *.class
 *.log

--- a/README.md
+++ b/README.md
@@ -22,6 +22,12 @@
 
 ## Development
 
+- Verwendung der Stable-Flutter-Version:
+  ```bash
+  flutter channel stable
+  flutter updrade
+  ```
+
 ### Formatting
 
 - Install VSCode-Extension: [Flutter](https://marketplace.visualstudio.com/items?itemName=Dart-Code.flutter)

--- a/lib/app.dart
+++ b/lib/app.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:take_me_home/presentation/pages/pages.dart';
+import 'package:take_me_home/presentation/router/app_router.dart';
 
 class App extends StatefulWidget {
   const App({super.key});
@@ -11,8 +12,14 @@ class App extends StatefulWidget {
 class _AppState extends State<App> {
   @override
   Widget build(BuildContext context) {
-    return const Scaffold(
-      body: SafeArea(
+    return Scaffold(
+      floatingActionButton: FloatingActionButton(
+        onPressed: () {
+          Navigator.of(context).pushNamed(AppRouter.createOrEditHome);
+        },
+        child: const Icon(Icons.add),
+      ),
+      body: const SafeArea(
         child: Scrollbar(
           child: SingleChildScrollView(
             child: ShowHomesPage(),

--- a/lib/app.dart
+++ b/lib/app.dart
@@ -2,6 +2,8 @@ import 'package:flutter/material.dart';
 import 'package:take_me_home/presentation/pages/pages.dart';
 import 'package:take_me_home/presentation/router/app_router.dart';
 
+/// Wrapper for the [MainApp].
+/// Controls logic for stuff like tabs, etc.
 class App extends StatefulWidget {
   const App({super.key});
 

--- a/lib/app.dart
+++ b/lib/app.dart
@@ -1,0 +1,24 @@
+import 'package:flutter/material.dart';
+import 'package:take_me_home/presentation/pages/pages.dart';
+
+class App extends StatefulWidget {
+  const App({super.key});
+
+  @override
+  State<App> createState() => _AppState();
+}
+
+class _AppState extends State<App> {
+  @override
+  Widget build(BuildContext context) {
+    return const Scaffold(
+      body: SafeArea(
+        child: Scrollbar(
+          child: SingleChildScrollView(
+            child: ShowHomesPage(),
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,20 +1,30 @@
 import 'package:flutter/material.dart';
 
+import 'presentation/router/app_router.dart';
+
 void main() {
-  runApp(const MainApp());
+  runApp(MainApp(
+    appRouter: AppRouter(),
+  ));
 }
 
 class MainApp extends StatelessWidget {
-  const MainApp({super.key});
+  final AppRouter appRouter;
+
+  const MainApp({
+    required this.appRouter,
+    super.key,
+  });
+
+  static String get title => 'Take Me Home';
 
   @override
   Widget build(BuildContext context) {
-    return const MaterialApp(
-      home: Scaffold(
-        body: Center(
-          child: Text('Hello World!'),
-        ),
-      ),
+    return MaterialApp(
+      title: MainApp.title,
+      debugShowCheckedModeBanner: false,
+      initialRoute: AppRouter.root,
+      onGenerateRoute: (settings) => appRouter.onGenerateRoute(settings),
     );
   }
 }

--- a/lib/presentation/pages/create_or_edit_home_page.dart
+++ b/lib/presentation/pages/create_or_edit_home_page.dart
@@ -1,0 +1,15 @@
+import 'package:flutter/material.dart';
+
+class CreateOrEditHomePage extends StatefulWidget {
+  const CreateOrEditHomePage({super.key});
+
+  @override
+  State<CreateOrEditHomePage> createState() => _CreateOrEditHomePageState();
+}
+
+class _CreateOrEditHomePageState extends State<CreateOrEditHomePage> {
+  @override
+  Widget build(BuildContext context) {
+    return const Text('Create or Edit Home Page');
+  }
+}

--- a/lib/presentation/pages/create_or_edit_home_page.dart
+++ b/lib/presentation/pages/create_or_edit_home_page.dart
@@ -1,7 +1,15 @@
 import 'package:flutter/material.dart';
 
+/// A home can be created ([isEditing] = false) or edited ([isEditing] = true) with this page.
+///
+/// Adjusts the UI based on the [isEditing] value.
 class CreateOrEditHomePage extends StatefulWidget {
-  const CreateOrEditHomePage({super.key});
+  final bool isEditing;
+
+  const CreateOrEditHomePage({
+    super.key,
+    required this.isEditing,
+  });
 
   @override
   State<CreateOrEditHomePage> createState() => _CreateOrEditHomePageState();

--- a/lib/presentation/pages/create_or_edit_home_page.dart
+++ b/lib/presentation/pages/create_or_edit_home_page.dart
@@ -10,6 +10,12 @@ class CreateOrEditHomePage extends StatefulWidget {
 class _CreateOrEditHomePageState extends State<CreateOrEditHomePage> {
   @override
   Widget build(BuildContext context) {
-    return const Text('Create or Edit Home Page');
+    return const Scaffold(
+      body: SafeArea(
+        child: Center(
+          child: Text('Create Or Edit Home Page'),
+        ),
+      ),
+    );
   }
 }

--- a/lib/presentation/pages/pages.dart
+++ b/lib/presentation/pages/pages.dart
@@ -1,0 +1,3 @@
+export 'show_homes_page.dart';
+export 'create_or_edit_home_page.dart';
+export 'show_way_to_home_page.dart';

--- a/lib/presentation/pages/show_homes_page.dart
+++ b/lib/presentation/pages/show_homes_page.dart
@@ -1,0 +1,15 @@
+import 'package:flutter/material.dart';
+
+class ShowHomesPage extends StatefulWidget {
+  const ShowHomesPage({super.key});
+
+  @override
+  State<ShowHomesPage> createState() => _ShowHomesPageState();
+}
+
+class _ShowHomesPageState extends State<ShowHomesPage> {
+  @override
+  Widget build(BuildContext context) {
+    return const Text('Show Homes Page');
+  }
+}

--- a/lib/presentation/pages/show_way_to_home_page.dart
+++ b/lib/presentation/pages/show_way_to_home_page.dart
@@ -1,5 +1,9 @@
 import 'package:flutter/material.dart';
 
+/// Show one trip to the selected home with single stations,
+/// time between the stations and information to each single station.
+///
+/// The home was selected in [ShowHomesPage].
 class ShowWayToHomePage extends StatefulWidget {
   const ShowWayToHomePage({super.key});
 

--- a/lib/presentation/pages/show_way_to_home_page.dart
+++ b/lib/presentation/pages/show_way_to_home_page.dart
@@ -1,0 +1,15 @@
+import 'package:flutter/material.dart';
+
+class ShowWayToHomePage extends StatefulWidget {
+  const ShowWayToHomePage({super.key});
+
+  @override
+  State<ShowWayToHomePage> createState() => _ShowWayToHomePageState();
+}
+
+class _ShowWayToHomePageState extends State<ShowWayToHomePage> {
+  @override
+  Widget build(BuildContext context) {
+    return const Text('Show Way To Home Page');
+  }
+}

--- a/lib/presentation/router/app_router.dart
+++ b/lib/presentation/router/app_router.dart
@@ -1,15 +1,16 @@
 import 'package:flutter/material.dart';
+import 'package:take_me_home/app.dart';
 import '../pages/pages.dart';
 
 class AppRouter {
-  static const String showHomes = '/';
+  static const String root = '/';
   static const String createOrEditHome = '/create_or_edit_home';
   static const String showWayToHome = '/show_way_to_home';
 
   Route? onGenerateRoute(RouteSettings settings) {
     switch (settings.name) {
-      case showHomes:
-        return MaterialPageRoute(builder: (_) => const ShowHomesPage());
+      case root:
+        return MaterialPageRoute(builder: (_) => const App());
       case createOrEditHome:
         return MaterialPageRoute(builder: (_) => const CreateOrEditHomePage());
       case showWayToHome:

--- a/lib/presentation/router/app_router.dart
+++ b/lib/presentation/router/app_router.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:take_me_home/app.dart';
 import '../pages/pages.dart';
 
+/// Lets you route between different pages in the app.
 class AppRouter {
   static const String root = '/';
   static const String createOrEditHome = '/create_or_edit_home';
@@ -12,7 +13,9 @@ class AppRouter {
       case root:
         return MaterialPageRoute(builder: (_) => const App());
       case createOrEditHome:
-        return MaterialPageRoute(builder: (_) => const CreateOrEditHomePage());
+        return MaterialPageRoute(
+          builder: (_) => const CreateOrEditHomePage(isEditing: false),
+        );
       case showWayToHome:
         return MaterialPageRoute(builder: (_) => const ShowWayToHomePage());
       default:

--- a/lib/presentation/router/app_router.dart
+++ b/lib/presentation/router/app_router.dart
@@ -1,0 +1,21 @@
+import 'package:flutter/material.dart';
+import '../pages/pages.dart';
+
+class AppRouter {
+  static const String showHomes = '/';
+  static const String createOrEditHome = '/create_or_edit_home';
+  static const String showWayToHome = '/show_way_to_home';
+
+  Route? onGenerateRoute(RouteSettings settings) {
+    switch (settings.name) {
+      case showHomes:
+        return MaterialPageRoute(builder: (_) => const ShowHomesPage());
+      case createOrEditHome:
+        return MaterialPageRoute(builder: (_) => const CreateOrEditHomePage());
+      case showWayToHome:
+        return MaterialPageRoute(builder: (_) => const ShowWayToHomePage());
+      default:
+        return null;
+    }
+  }
+}


### PR DESCRIPTION
* ich habe mal eine anfängliche Struktur geschaffen, damit theoretisch schonmal unabhängig voneinander Dinge gemacht werden können und wir uns nicht in die Quere kommen beim Anfang
* beim Routing kann man sich ein Beispiel in `show_homes_page.dart` anschauen
  -> die Klasse `AppRouter` ist für alles, was Routing angeht, verantwortlich
  -> wenn eine neue Page hinzugefügt wird, dann an diesem Beispiel orientieren (für Beispiele mit Argumenten, s. bspw. Gasta-Admin-App)
* Aufteilung in `main.dart` und `app.dart`